### PR TITLE
Update package metadata from GitHub

### DIFF
--- a/content/freecal.md
+++ b/content/freecal.md
@@ -1,12 +1,12 @@
 ---
-title: "freecal"
-import_path: "go.ngs.io/freecal"
-repo_url: "https://github.com/ngs/freecal"
+title: freecal
+import_path: go.ngs.io/freecal
+repo_url: https://github.com/ngs/freecal
 description: ""
-version: "v1.0.0"
-documentation_url: "https://pkg.go.dev/go.ngs.io/freecal"
-license: "MIT"
-author: "Atsushi Nagase"
-created_at: "2025-08-12T07:37:35Z"
-updated_at: "2025-08-12T07:32:37Z"
+version: v1.0.0
+documentation_url: https://pkg.go.dev/go.ngs.io/freecal
+license: MIT
+author: Atsushi Nagase
+created_at: 2025-08-12T07:37:35Z
+updated_at: 2025-08-12T09:32:37Z
 ---

--- a/update-output.txt
+++ b/update-output.txt
@@ -1,0 +1,8 @@
+Updating packages from GitHub...
+
+✓ freecal - updated_at
+
+Validating site build...
+✓ Site builds successfully
+
+Summary: 1 updated


### PR DESCRIPTION
This PR updates package metadata from GitHub API.

## Updated Packages
freecal 

## Update Summary
```
$(cat update-output.txt)
```

## Trigger
- Workflow: workflow_dispatch
- Run: [2](https://github.com/ngs/go.ngs.io/actions/runs/16908084206)
- Packages: All

Please review the changes and merge if everything looks correct.