### PR TITLE
Add servedir package

### DIFF
--- a/content/servedir.md
+++ b/content/servedir.md
@@ -1,0 +1,12 @@
+---
+title: servedir
+import_path: go.ngs.io/servedir
+repo_url: https://github.com/ngs/servedir
+description: Simple HTTP server that hosts local directory statically.
+version: v1.0.1
+documentation_url: https://pkg.go.dev/go.ngs.io/servedir
+license: MIT
+author: ngs
+created_at: 2018-04-16T01:22:33Z
+updated_at: 2025-08-12T11:40:51Z
+---


### PR DESCRIPTION
This PR adds the `servedir` package to go.ngs.io.

## Package Details
- **Name**: servedir
- **Repository**: Auto-detected
- **Import Path**: go.ngs.io/servedir
- **Author**: Auto-detected

## Trigger
- Workflow: Manual dispatch
- Run: [1](https://github.com/ngs/go.ngs.io/actions/runs/16908195612)

Please review the generated package file and merge if everything looks correct.