### PR TITLE
Add jplaw2epub package

### DIFF
--- a/content/jplaw2epub.md
+++ b/content/jplaw2epub.md
@@ -1,0 +1,12 @@
+---
+title: jplaw2epub
+import_path: go.ngs.io/jplaw2epub
+repo_url: https://github.com/ngs/jplaw2epub
+description: ""
+version: v1.0.0
+documentation_url: https://pkg.go.dev/go.ngs.io/jplaw2epub
+license: MIT
+author: ngs
+created_at: 2025-02-09T00:46:45Z
+updated_at: 2025-08-12T17:44:01Z
+---


### PR DESCRIPTION
This PR adds the `jplaw2epub` package to go.ngs.io.

## Package Details
- **Name**: jplaw2epub
- **Repository**: Auto-detected
- **Import Path**: go.ngs.io/jplaw2epub
- **Author**: Auto-detected

## Trigger
- Workflow: Manual dispatch
- Run: [5](https://github.com/ngs/go.ngs.io/actions/runs/16916596482)

Please review the generated package file and merge if everything looks correct.