### PR TITLE
Add law-api-v2 package

### DIFF
--- a/content/law-api-v2.md
+++ b/content/law-api-v2.md
@@ -1,0 +1,12 @@
+---
+title: law-api-v2
+import_path: go.ngs.io/jplaw-api-v2
+repo_url: https://github.com/ngs/go-jplaw-api-v2
+description: Go Client library for Japanese Laws API Version 2
+version: v0.0.1
+documentation_url: https://pkg.go.dev/go.ngs.io/jplaw-api-v2
+license: ""
+author: ngs
+created_at: 2025-08-12T21:59:41Z
+updated_at: 2025-08-12T22:14:58Z
+---


### PR DESCRIPTION
This PR adds the `law-api-v2` package to go.ngs.io.

## Package Details
- **Name**: law-api-v2
- **Repository**: https://github.com/ngs/go-jplaw-api-v2
- **Import Path**: go.ngs.io/jplaw-api-v2
- **Author**: Auto-detected

## Trigger
- Workflow: Manual dispatch
- Run: [6](https://github.com/ngs/go.ngs.io/actions/runs/16922199149)

Please review the generated package file and merge if everything looks correct.