### PR TITLE
Add google-mcp-server package

### DIFF
--- a/content/google-mcp-server.md
+++ b/content/google-mcp-server.md
@@ -1,0 +1,12 @@
+---
+title: google-mcp-server
+import_path: google-mcp-server
+repo_url: https://github.com/ngs/google-mcp-server
+description: A Model Context Protocol (MCP) server that integrates with Google APIs (Calendar, Drive, Gmail, Photos, Sheets, Docs) to provide seamless access to Google services through MCP-compatible clients.
+version: v0.0.1
+documentation_url: https://pkg.go.dev/google-mcp-server
+license: MIT
+author: '"Atsushi'
+created_at: 2025-09-08T06:04:17Z
+updated_at: 2025-09-08T09:59:39Z
+---


### PR DESCRIPTION
This PR adds the `google-mcp-server` package to go.ngs.io.

## Package Details
- **Name**: google-mcp-server
- **Repository**: https://github.com/ngs/google-mcp-server
- **Import Path**: google-mcp-server
- **Author**: Atsushi Nagase

## Trigger
- Workflow: Manual dispatch
- Run: [7](https://github.com/ngs/go.ngs.io/actions/runs/17547036474)

Please review the generated package file and merge if everything looks correct.