### PR TITLE
Support dark theme and package metadata display

### DIFF
--- a/content/tides-api.md
+++ b/content/tides-api.md
@@ -5,7 +5,7 @@ repo_url: https://github.com/ngs/tides-api
 description: A high-performance tidal prediction API written in Go, providing harmonic tidal analysis with support for multiple data sources.
 version: ""
 documentation_url: https://pkg.go.dev/go.ngs.io/tides-api
-license: NOASSERTION
+license: MIT
 author: ngs
 created_at: 2025-10-20T20:48:48Z
 updated_at: 2026-06-22T22:01:39Z
@@ -486,7 +486,10 @@ The codebase is designed for easy extension:
 
 ## License
 
-[Specify your license here]
+MIT License. See [LICENSE](LICENSE) for details.
+
+See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for third-party package
+notices and FES data licensing notes.
 
 ## Attribution
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,6 +9,17 @@
     {{ end }}
     <title>{{ .Title }} - {{ .Site.Title }}</title>
     <meta name="description" content="{{ .Param "description" | default .Site.Params.description }}">
+    <meta name="color-scheme" content="light dark">
+    <script>
+        (function () {
+            try {
+                var theme = localStorage.getItem("theme") || "auto";
+                document.documentElement.setAttribute("data-theme", theme);
+            } catch (error) {
+                document.documentElement.setAttribute("data-theme", "auto");
+            }
+        })();
+    </script>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="stylesheet" href="/css/main.css">
 </head>
@@ -27,7 +38,45 @@
     </main>
     
     <footer>
-        <p>&copy; {{ now.Year }} <a href="https://ngs.io">Atsushi Nagase</a>. All rights reserved.</p>
+        <div class="footer-inner">
+            <p>&copy; {{ now.Year }} <a href="https://ngs.io">Atsushi Nagase</a>. All rights reserved.</p>
+            <div class="theme-switcher" role="group" aria-label="Theme">
+                <button type="button" data-theme-option="auto">System</button>
+                <button type="button" data-theme-option="dark">Dark</button>
+                <button type="button" data-theme-option="light">Light</button>
+            </div>
+        </div>
     </footer>
+    <script>
+        (function () {
+            var storageKey = "theme";
+            var root = document.documentElement;
+            var buttons = document.querySelectorAll("[data-theme-option]");
+            var validThemes = ["auto", "dark", "light"];
+
+            function normalizeTheme(theme) {
+                return validThemes.indexOf(theme) === -1 ? "auto" : theme;
+            }
+
+            function applyTheme(theme) {
+                theme = normalizeTheme(theme);
+                root.setAttribute("data-theme", theme);
+                try {
+                    localStorage.setItem(storageKey, theme);
+                } catch (error) {
+                }
+                buttons.forEach(function (button) {
+                    button.setAttribute("aria-pressed", button.dataset.themeOption === theme ? "true" : "false");
+                });
+            }
+
+            applyTheme(root.getAttribute("data-theme"));
+            buttons.forEach(function (button) {
+                button.addEventListener("click", function () {
+                    applyTheme(button.dataset.themeOption);
+                });
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,8 +11,10 @@
     </div>
     
     <dl class="package-info">
+        {{ with .Param "version" }}
         <dt>Version:</dt>
-        <dd>{{ .Param "version" }}</dd>
+        <dd>{{ . }}</dd>
+        {{ end }}
         
         <dt>License:</dt>
         <dd>{{ .Param "license" }}</dd>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -15,10 +15,16 @@
             <div class="package-card">
                 <h3><a href="{{ .RelPermalink }}">{{ .Param "import_path" }}</a></h3>
                 <p>{{ .Param "description" }}</p>
+                {{ if or (.Param "version") (.Param "license") }}
                 <div class="package-meta">
-                    <span class="version">{{ .Param "version" }}</span>
-                    <span class="license">{{ .Param "license" }}</span>
+                    {{ with .Param "version" }}
+                    <span class="version">{{ . }}</span>
+                    {{ end }}
+                    {{ with .Param "license" }}
+                    <span class="license">{{ . }}</span>
+                    {{ end }}
                 </div>
+                {{ end }}
                 <div class="package-links">
                     <a href="{{ .Param "repo_url" }}" target="_blank">GitHub</a>
                     {{ if .Param "documentation_url" }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,10 +1,63 @@
 :root {
-    --primary-color: #00ADD8;
+    color-scheme: light;
+
+    --primary-color: #007d9c;
     --secondary-color: #007d9c;
-    --text-color: #333;
+    --text-color: #202224;
+    --muted-text-color: #6e7072;
     --bg-color: #fff;
-    --border-color: #e0e0e0;
-    --card-bg: #f9f9f9;
+    --border-color: #c6c8ca;
+    --card-bg: #f8f8f8;
+    --surface-bg: #fff;
+    --code-bg: #f0f1f2;
+    --header-bg: #007d9c;
+    --header-text-color: #fff;
+    --footer-bg: #f5f5f5;
+    --footer-text-color: #6e7072;
+    --shadow-color: rgba(0, 0, 0, 0.16);
+    --focus-color: rgba(0, 125, 156, 0.55);
+}
+
+[data-theme="dark"] {
+    color-scheme: dark;
+
+    --primary-color: #50b7e0;
+    --secondary-color: #5dc9e2;
+    --text-color: #f0f1f2;
+    --muted-text-color: #c6c8ca;
+    --bg-color: #202224;
+    --border-color: #6e7072;
+    --card-bg: #2b2d30;
+    --surface-bg: #202224;
+    --code-bg: #3e4042;
+    --header-bg: #007d9c;
+    --header-text-color: #fff;
+    --footer-bg: #253443;
+    --footer-text-color: #f0f1f2;
+    --shadow-color: rgba(0, 0, 0, 0.45);
+    --focus-color: rgba(80, 183, 224, 0.65);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+        color-scheme: dark;
+
+        --primary-color: #50b7e0;
+        --secondary-color: #5dc9e2;
+        --text-color: #f0f1f2;
+        --muted-text-color: #c6c8ca;
+        --bg-color: #202224;
+        --border-color: #6e7072;
+        --card-bg: #2b2d30;
+        --surface-bg: #202224;
+        --code-bg: #3e4042;
+        --header-bg: #007d9c;
+        --header-text-color: #fff;
+        --footer-bg: #253443;
+        --footer-text-color: #f0f1f2;
+        --shadow-color: rgba(0, 0, 0, 0.45);
+        --focus-color: rgba(80, 183, 224, 0.65);
+    }
 }
 
 * {
@@ -27,10 +80,10 @@ body {
 }
 
 header {
-    background-color: var(--primary-color);
-    color: white;
+    background-color: var(--header-bg);
+    color: var(--header-text-color);
     padding: 1rem 0;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 4px var(--shadow-color);
 }
 
 header nav {
@@ -45,7 +98,7 @@ header nav {
 header .logo {
     font-size: 1.5rem;
     font-weight: bold;
-    color: white;
+    color: var(--header-text-color);
     text-decoration: none;
 }
 
@@ -56,9 +109,15 @@ header ul {
 }
 
 header ul a {
-    color: white;
+    color: var(--header-text-color);
     text-decoration: none;
     transition: opacity 0.3s;
+}
+
+a:focus-visible,
+button:focus-visible {
+    outline: 3px solid var(--focus-color);
+    outline-offset: 3px;
 }
 
 header ul a:hover {
@@ -78,7 +137,7 @@ h1 {
 
 .lead {
     font-size: 1.25rem;
-    color: #666;
+    color: var(--muted-text-color);
     margin-bottom: 3rem;
 }
 
@@ -116,7 +175,7 @@ h1 {
 
 .package-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 350px), 1fr));
     gap: 2rem;
     margin-bottom: 3rem;
 }
@@ -131,7 +190,7 @@ h1 {
 
 .package-card:hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    box-shadow: 0 4px 12px var(--shadow-color);
 }
 
 .package-card h3 {
@@ -149,7 +208,7 @@ h1 {
 }
 
 .package-card p {
-    color: #666;
+    color: var(--muted-text-color);
     margin-bottom: 1rem;
 }
 
@@ -162,7 +221,7 @@ h1 {
 
 .package-meta span {
     padding: 0.25rem 0.5rem;
-    background: white;
+    background: var(--surface-bg);
     border: 1px solid var(--border-color);
     border-radius: 4px;
 }
@@ -172,11 +231,12 @@ h1 {
 }
 
 .license {
-    color: #666;
+    color: var(--muted-text-color);
 }
 
 .package-links {
     display: flex;
+    flex-wrap: wrap;
     gap: 1rem;
 }
 
@@ -192,15 +252,64 @@ h1 {
 
 .package-links a:hover {
     background-color: var(--primary-color);
-    color: white;
+    color: var(--bg-color);
 }
 
 footer {
-    background-color: #f5f5f5;
-    text-align: center;
+    background-color: var(--footer-bg);
     padding: 2rem 0;
-    color: #666;
+    color: var(--footer-text-color);
     border-top: 1px solid var(--border-color);
+}
+
+footer a {
+    color: inherit;
+}
+
+.footer-inner {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem 1.5rem;
+    justify-content: space-between;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+.footer-inner p {
+    margin: 0;
+}
+
+.theme-switcher {
+    align-items: center;
+    background: var(--surface-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    display: inline-flex;
+    overflow: hidden;
+}
+
+.theme-switcher button {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    border-right: 1px solid var(--border-color);
+    color: var(--text-color);
+    cursor: pointer;
+    font-size: 0.875rem;
+    line-height: 1;
+    padding: 0.625rem 0.75rem;
+}
+
+.theme-switcher button:last-child {
+    border-right: 0;
+}
+
+.theme-switcher button:hover,
+.theme-switcher button[aria-pressed="true"] {
+    background: var(--primary-color);
+    color: var(--bg-color);
 }
 
 .package-detail {
@@ -219,11 +328,12 @@ footer {
 }
 
 .import-command {
-    background: #f5f5f5;
+    background: var(--code-bg);
     padding: 1rem;
     border-radius: 4px;
     font-family: monospace;
     margin: 1rem 0;
+    overflow-x: auto;
 }
 
 .package-info {
@@ -235,7 +345,7 @@ footer {
 
 .package-info dt {
     font-weight: bold;
-    color: #666;
+    color: var(--muted-text-color);
 }
 
 .package-info dd {
@@ -275,7 +385,8 @@ footer {
 }
 
 .package-detail pre {
-    background: #f5f5f5;
+    background: var(--code-bg);
+    border: 1px solid var(--border-color);
     padding: 1rem;
     border-radius: 4px;
     overflow-x: auto;
@@ -289,7 +400,7 @@ footer {
 
 .package-detail p code,
 .package-detail li code {
-    background: #f5f5f5;
+    background: var(--code-bg);
     padding: 0.2rem 0.4rem;
     border-radius: 3px;
 }
@@ -308,7 +419,7 @@ footer {
     border-left: 4px solid var(--primary-color);
     padding-left: 1rem;
     margin: 1rem 0;
-    color: #666;
+    color: var(--muted-text-color);
 }
 
 .package-detail a {
@@ -338,5 +449,47 @@ footer {
 }
 
 .package-detail th {
-    background: #f5f5f5;
+    background: var(--code-bg);
+}
+
+@media (max-width: 520px) {
+    .container,
+    header nav,
+    .footer-inner {
+        padding: 0 16px;
+    }
+
+    header .logo {
+        font-size: 1.125rem;
+    }
+
+    header ul {
+        gap: 1rem;
+    }
+
+    main {
+        padding: 2rem 0;
+    }
+
+    h1 {
+        font-size: 2rem;
+    }
+
+    .package-info {
+        grid-template-columns: 1fr;
+        gap: 0.25rem;
+    }
+
+    .package-info dd {
+        margin-bottom: 0.75rem;
+        overflow-wrap: anywhere;
+    }
+
+    .theme-switcher {
+        width: 100%;
+    }
+
+    .theme-switcher button {
+        flex: 1;
+    }
 }


### PR DESCRIPTION
## Summary

- Add automatic and manual light/dark theme support for the Hugo site.
- Add a footer theme switcher with persisted `auto`, `dark`, and `light` choices.
- Hide empty package versions on index cards and package detail pages.
- Correct `tides-api` metadata from `NOASSERTION` to `MIT` and update its rendered license text.

## Why

The site should behave like pkg.go.dev for dark theme users, while packages without detected versions should not render empty UI placeholders. `tides-api` was displaying `NOASSERTION` because the source repository license file mixed the MIT license with third-party notices.

## Validation

- `hugo --gc --minify`
- Confirmed generated `tides-api` HTML shows `MIT` and omits the empty `Version:` row.
- Existing Hugo warning remains: missing home JSON layout for the configured JSON output.