### PR TITLE
Skip timestamp-only package update PRs

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -83,15 +83,32 @@ jobs:
         id: changes
         if: github.event.inputs.dry-run != 'true'
         run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "has-changes=true" >> $GITHUB_OUTPUT
-            
-            # Get list of modified files
-            MODIFIED_FILES=$(git diff --name-only | grep "^content/" | sed 's/content\///; s/\.md$//' | tr '\n' ' ')
-            echo "modified-packages=$MODIFIED_FILES" >> $GITHUB_OUTPUT
-          else
+          CHANGED_FILES=$(git diff --name-only)
+
+          if [ -z "$CHANGED_FILES" ]; then
             echo "has-changes=false" >> $GITHUB_OUTPUT
             echo "No packages needed updating."
+            exit 0
+          fi
+
+          NON_TIMESTAMP_CHANGES=$(git diff --unified=0 -- content/*.md | awk '
+            /^(\+\+\+|---) / { next }
+            /^[+-]/ && $0 !~ /^[+-](created_at|updated_at):[[:space:]]+"?[0-9TZ:+.-]+"?$/ { print }
+          ')
+
+          NON_CONTENT_CHANGES=$(printf '%s\n' "$CHANGED_FILES" | grep -vE '^content/[^/]+\.md$' || true)
+
+          if [ -z "$NON_CONTENT_CHANGES" ] && [ -z "$NON_TIMESTAMP_CHANGES" ]; then
+            echo "has-changes=false" >> $GITHUB_OUTPUT
+            echo "timestamp-only=true" >> $GITHUB_OUTPUT
+            echo "Only package timestamp metadata changed; skipping PR."
+            git diff --stat -- content
+          else
+            echo "has-changes=true" >> $GITHUB_OUTPUT
+
+            # Get list of modified packages
+            MODIFIED_FILES=$(printf '%s\n' "$CHANGED_FILES" | grep "^content/" | sed 's/content\///; s/\.md$//' | tr '\n' ' ')
+            echo "modified-packages=$MODIFIED_FILES" >> $GITHUB_OUTPUT
           fi
       
       - name: Configure Git


### PR DESCRIPTION
## Summary

- Detect when `update-packages` only changes `created_at` or `updated_at` fields in package front matter.
- Skip commit, push, and PR creation for timestamp-only metadata updates.
- Keep normal PR creation behavior when package content, license, description, version, README, or workflow files change.

## Why

Scheduled package updates can create noisy pull requests when GitHub metadata only changes timestamps. Those updates do not affect package display in a meaningful way, so the workflow should avoid opening PRs for them.

## Validation

- `git diff --check`
- Manually checked the awk filter: timestamp-only lines are ignored, while non-timestamp metadata such as `license` is detected.